### PR TITLE
(MAINT) Use VMPOOLER_TOKEN instead of VMPOOL_TOKEN

### DIFF
--- a/TODO
+++ b/TODO
@@ -4,7 +4,7 @@ Current issues
  * We should be able to tell when a failure is token based vs other params
  * We should basically have three levels of permissions:
     - unauthenticated you get CRD on VMs but no update and low default lifetime
-    - VMPOOL_TOKEN set - you get CRUD on VMs but can't manipulate tokens
+    - VMPOOLER_TOKEN set - you get CRUD on VMs but can't manipulate tokens
     - LDAP_PASSWORD and LDAP_USERNAME set -- full access
 
  Version 2

--- a/formula/vmpool.rb
+++ b/formula/vmpool.rb
@@ -30,6 +30,6 @@ class Vmpool < Formula
   end
 
   def caveats
-    "Be sure you have LDAP_USERNAME and LDAP_PASSWORD, or VMPOOL_TOKEN set. See man page for more information."
+    "Be sure you have LDAP_USERNAME and LDAP_PASSWORD, or VMPOOLER_TOKEN set. See man page for more information."
   end
 end

--- a/manpage.md
+++ b/manpage.md
@@ -141,7 +141,7 @@ Alter the lifetime of a VM.
 
 **VMPOOL_LOGFILE** - Location of the application log for vmpool. By default this is in `$HOME/.vmpool.log`.
 
-**VMPOOL_TOKEN** - If you already have a TOKEN for the vmpooler, you may specify it here. This will reduce HTTP calls to the pooler and may cause a very slight performance boost. 
+**VMPOOLER_TOKEN** - If you already have a TOKEN for the vmpooler, you may specify it here. This will reduce HTTP calls to the pooler and may cause a very slight performance boost. 
 
 **VMPOOL_URL** - This is the URL of the vmpooler you are connecting to. This defaults to https://vmpooler.delivery.puppetlabs.net
 

--- a/token.go
+++ b/token.go
@@ -86,12 +86,12 @@ func deleteToken(token string) {
 
 func processEnvForToken() string {
 	debug("Function: processEnvForToken")
-	if os.Getenv("VMPOOL_TOKEN") != "" {
-		//		if isValidToken(os.Getenv("VMPOOL_TOKEN")) {
-		logmsg("Using VMPOOL_TOKEN...assuming it is valid: " + os.Getenv("VMPOOL_TOKEN"))
-		debug("VMPOOL_TOKEN...assuming it is valid: " + os.Getenv("VMPOOL_TOKEN"))
-		debug("  Returning " + os.Getenv("VMPOOL_TOKEN"))
-		return os.Getenv("VMPOOL_TOKEN")
+	if os.Getenv("VMPOOLER_TOKEN") != "" {
+		//		if isValidToken(os.Getenv("VMPOOLER_TOKEN")) {
+		logmsg("Using VMPOOLER_TOKEN...assuming it is valid: " + os.Getenv("VMPOOLER_TOKEN"))
+		debug("VMPOOLER_TOKEN...assuming it is valid: " + os.Getenv("VMPOOLER_TOKEN"))
+		debug("  Returning " + os.Getenv("VMPOOLER_TOKEN"))
+		return os.Getenv("VMPOOLER_TOKEN")
 		//}
 
 	}
@@ -107,7 +107,7 @@ func grantToken() string {
 		params := ldapsetup()
 		_, output_json := RequestWrapper("token", params, "POST", "{}")
 		newtoken = fmt.Sprintf("%v", output_json["token"])
-		os.Setenv("VMPOOL_TOKEN", newtoken)
+		os.Setenv("VMPOOLER_TOKEN", newtoken)
 		logmsg(fmt.Sprintf("Aquired token: %v", newtoken))
 		fmt.Println(fmt.Sprintf("Aquired token: %v", newtoken))
 	}


### PR DESCRIPTION
We're trying to standardize on a semantically clear environment
variable name across multiple tools.