### PR TITLE
Correct usage for `vmpool delete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After you grab the VM, you'll need to use the testing (beaker) private key to ac
 
 ## Delete a VM
 
-    vmpool delete <pool name>
+    vmpool delete <vm name>
 
 
 Deleting a VM is good for the overall resource utilization if you're done with the VM. They will be destroyed in 12 hours if you don't remove them before that.


### PR DESCRIPTION
![](http://freelancetofreedomproject.com/wp-content/uploads/2015/08/Heather-StopTweaking.png)

Just a tiny tweak -- we delete by specifying a specific VM, not a pool.

/cc @stahnma 
